### PR TITLE
README V2 - Update setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,4 @@ and then add this as the first repo as described [on Spack's readme](https://spa
 $ cat repos.yaml
 	repos:
 	  - /Users/myuser/spack-repo
-	  - $spack/var/spack/repos/builtin
-
 ```


### PR DESCRIPTION
Remove the old default repo location from sample config. No longer needed (and also ignored).