### PR TITLE
MeteoIO - Add V2.11.0 

### DIFF
--- a/spack_repo/chm/packages/chm/package.py
+++ b/spack_repo/chm/packages/chm/package.py
@@ -72,7 +72,7 @@ class Chm(CMakePackage):
     depends_on("intel-oneapi-tbb", when="platform=linux")
 
     depends_on("eigen")
-    depends_on("meteoio")
+    depends_on("meteoio@2.8.0")
     depends_on("func@2.2: ~openmp", when="~openmp")
     depends_on("func@2.2: +openmp", when="+openmp")
 

--- a/spack_repo/chm/packages/meteoio/package.py
+++ b/spack_repo/chm/packages/meteoio/package.py
@@ -18,6 +18,7 @@ class Meteoio(CMakePackage):
 
     license("LGPL-3.0-or-later", checked_by="Chrismarsh")
 
+    version("2.11.0", sha256="59bae16be57188639d81eb0131e50e54bbf1359614601c768b7fc4d2e36b295d")
     version("2.8.0", sha256="898bf0d0329000e7ae18064c30ea72362aac447deda0b013ee22e4aa63563efd")
 
     depends_on("c", type="build")


### PR DESCRIPTION
MeteoIO 2.11.0 required for snowpack 3.7.0
The old version (2.8.0) is kept for the current and past versions of CHM

Note: when releasing CHM with the new snowpack version, need to specify that we're using 2.11.0